### PR TITLE
build: add production Docker image and GHCR workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,30 @@
+# Git
+.gitignore
+
+# Node / build artifacts
+node_modules
+/resources/_gen
+public
+.hugo_build.lock
+
+# Local caches
+official_cache
+official_cache_json
+official_cache_json2
+
+# IDE / editor settings
+.idea
+.vscode
+*.swp
+*.swo
+
+# Misc
+Dockerfile
+docker-compose.yaml
+.github
+netlify.toml
+todo.md
+fix_internal_links.py
+CONTRIBUTING.md
+LICENSE
+README.md

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,58 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - 'v*'
+  pull_request:
+    branches:
+      - master
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=,suffix=,format=short
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,27 @@
-FROM klakegg/hugo:ext-alpine
+# Stage 1: Build the static site with Hugo
+FROM klakegg/hugo:ext-alpine AS builder
 
-RUN apk add git && \
-  git config --global --add safe.directory /src
+WORKDIR /src
+
+# Install git (for Hugo's git info) and Node.js/npm (for PostCSS/Autoprefixer)
+RUN apk add --no-cache git nodejs npm && \
+    git config --global --add safe.directory /src
+
+# Install Node dependencies first so they can be cached if package files don't change
+COPY package*.json ./
+RUN npm ci
+
+# Copy the rest of the source
+COPY . .
+
+# Build the site
+RUN hugo --minify
+
+# Stage 2: Serve the generated site with nginx
+FROM nginx:alpine
+
+# Copy the built site from the builder stage
+COPY --from=builder /src/public /usr/share/nginx/html
+
+# Expose the HTTP port
+EXPOSE 80

--- a/README.md
+++ b/README.md
@@ -62,45 +62,63 @@ hugo server
 
 ## Running a container locally
 
-You can run docsy-example inside a [Docker](https://docs.docker.com/)
-container, the container runs with a volume bound to the `docsy-example`
-folder. This approach doesn't require you to install any dependencies other
-than [Docker Desktop](https://www.docker.com/products/docker-desktop) on
-Windows and Mac, and [Docker Compose](https://docs.docker.com/compose/install/)
-on Linux.
+The repository includes a production-ready `Dockerfile` that builds the static site
+with Hugo and serves it with nginx. You can run it locally with Docker or Docker Compose.
 
-1. Build the docker image 
+### Using Docker Compose
 
-   ```bash
-   docker-compose build
-   ```
+```bash
+docker-compose up --build
+```
 
-1. Run the built image
+Then open [http://localhost:8080](http://localhost:8080) in your browser.
 
-   ```bash
-   docker-compose up
-   ```
+### Using Docker directly
 
-   > NOTE: You can run both commands at once with `docker-compose up --build`.
+Build the image:
 
-1. Verify that the service is working. 
+```bash
+docker build -t itop-doc .
+```
 
-   Open your web browser and type `http://localhost:1313` in your navigation bar,
-   This opens a local instance of the docsy-example homepage. You can now make
-   changes to the docsy example and those changes will immediately show up in your
-   browser after you save.
+Run it:
+
+```bash
+docker run --rm -p 8080:80 itop-doc
+```
+
+Then open [http://localhost:8080](http://localhost:8080) in your browser.
+
+### Using the pre-built image from GitHub Container Registry
+
+A pre-built image is published to GitHub Container Registry on every push to `master`
+and every version tag:
+
+```bash
+docker run --rm -p 8080:80 ghcr.io/itop-china/itop-doc:latest
+```
+
+The image URL is:
+
+```
+ghcr.io/itop-china/itop-doc:latest
+```
 
 ### Cleanup
 
-To stop Docker Compose, on your terminal window, press **Ctrl + C**. 
+To stop Docker Compose, press **Ctrl + C** in the terminal window.
 
-To remove the produced images run:
+To remove the produced containers:
 
-```console
+```bash
 docker-compose rm
 ```
-For more information see the [Docker Compose
-documentation](https://docs.docker.com/compose/gettingstarted/).
+
+To remove the locally built image:
+
+```bash
+docker rmi itop-doc
+```
 
 ## Troubleshooting
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,13 +1,9 @@
 version: "3.3"
 
 services:
-
   site:
-    image: docsy/docsy-example
+    image: ghcr.io/itop-china/itop-doc:latest
     build:
       context: .
-    command: server
     ports:
-      - "1313:1313"
-    volumes:
-      - .:/src
+      - "8080:80"


### PR DESCRIPTION
- Switch Dockerfile to multi-stage build (Hugo + nginx)
- Add .dockerignore to reduce image size
- Update docker-compose.yaml for production image on port 8080
- Add GitHub Actions workflow to build and push to GHCR on master/tags
- Update README with new container run instructions